### PR TITLE
allow html5 <main> tag

### DIFF
--- a/lib/HTML/Lint/Pluggable/HTML5.pm
+++ b/lib/HTML/Lint/Pluggable/HTML5.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.05';
 use parent qw/ HTML::Lint::Pluggable::WhiteList /;
 use List::MoreUtils qw/any/;
 
-my %html5_tag = map { $_ => 1 } qw/article aside audio canvas command datalist details embed figcaption figure footer header hgroup keygen mark menu meter nav output progress section source summary time video rp rt ruby wbr/;
+my %html5_tag = map { $_ => 1 } qw/article aside audio canvas command datalist details embed figcaption figure footer header hgroup keygen main mark menu meter nav output progress section source summary time video rp rt ruby wbr/;
 
 my %html5_global_attr = map { $_ => 1 } qw/contenteditable contextmenu draggable dropzone hidden role spellcheck tabindex translate/;
 my @html5_global_user_attr = (qr/^aria-/, qr/^data-/);


### PR DESCRIPTION
The main tag was added later in the process, but was added to the w3c version of the HTML5 spec. http://www.w3.org/TR/html5/grouping-content.html#the-main-element