### PR TITLE
Add some available html5 tags

### DIFF
--- a/lib/HTML/Lint/Pluggable/HTML5.pm
+++ b/lib/HTML/Lint/Pluggable/HTML5.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.06';
 use parent qw/ HTML::Lint::Pluggable::WhiteList /;
 use List::MoreUtils qw/any/;
 
-my %html5_tag = map { $_ => 1 } qw/article aside audio canvas command datalist details embed figcaption figure footer header hgroup keygen main mark menu meter nav output progress section source summary time video rp rt ruby wbr/;
+my %html5_tag = map { $_ => 1 } qw/article aside audio bdi canvas command datalist details dialog embed figcaption figure footer header hgroup keygen main mark menu menuitem meter nav output progress section source summary template time track video rb rp rt rtc ruby wbr/;
 
 my %html5_global_attr = map { $_ => 1 } qw/contenteditable contextmenu draggable dropzone hidden role spellcheck tabindex translate/;
 my @html5_global_user_attr = (qr/^aria-/, qr/^data-/);


### PR DESCRIPTION
I added following html5 tags.

- bdi
- dialog
- menuitem
- template
- track
- rb, rtc
    - These are not defined by whatwg, but defined by w3c

I refered to following documents

- http://www.w3schools.com/html/html5_new_elements.asp
- https://html.spec.whatwg.org/multipage/indices.html
- https://www.w3.org/TR/html5/index.html#index